### PR TITLE
Add a recipe for a static library

### DIFF
--- a/mgilib_shm/Makefile
+++ b/mgilib_shm/Makefile
@@ -1,5 +1,6 @@
 
-all: mgilib2.o atm.Abs oce.Abs test.Abs mpi.Abs mgi_shm.Abs
+all: mgilib2.o atm.Abs oce.Abs test.Abs mpi.Abs mgi_shm.Abs libmgi.a
+
 
 mgi_shm.Abs: mgi_shm.c
 	s.cc -I. -O 2 -Dmgi_shm=main mgi_shm.c -o mgi_shm.Abs
@@ -19,6 +20,9 @@ test.Abs: mgilib2.o f_mgi_test.F90
 mgilib2.o: mgilib2.c mgi.h
 	s.cc -I. -c -DWITHOUT_GOSSIP -O 2 mgilib2.c -o mgilib2.o
 
+libmgi.a: mgilib2.o
+	ar rcv libmgi.a mgilib2.o
+
 clean:
-	rm -f mgilib2.o atm.Abs oce.Abs mgi_shm.Abs mpi.Abs
+	rm -f mgilib2.o atm.Abs oce.Abs mgi_shm.Abs mpi.Abs libmgi.a
 


### PR DESCRIPTION
I've added a recipe for a static library. Not sure if it'll work because in addition to gossip.o, previously I was also adding md5.o.

BTW: Is there a nice way to make CRCM use a custom static library? It would be nice If NEMO and CRCM used it from the same place..

Thanks
